### PR TITLE
Add published_at date picker to CMS editor

### DIFF
--- a/app/admin/blog/edit/[id]/page.tsx
+++ b/app/admin/blog/edit/[id]/page.tsx
@@ -45,6 +45,7 @@ export default function EditBlogPostPage({ params }: EditBlogPostPageProps) {
             author_image: result.post.author_image || "Rishabh Jain.jpeg",
             tags: result.post.tags || [],
             status: result.post.status,
+            published_at: result.post.published_at || "",
             meta_title: result.post.meta_title || result.post.title,
             meta_description: result.post.meta_description || "",
             meta_keywords: result.post.meta_keywords || []

--- a/app/api/blog/posts/id/[id]/route.ts
+++ b/app/api/blog/posts/id/[id]/route.ts
@@ -48,6 +48,7 @@ export async function PUT(
       author_image,
       tags,
       status,
+      published_at,
       meta_title,
       meta_description,
       meta_keywords
@@ -79,8 +80,16 @@ export async function PUT(
     if (meta_keywords) updateData.meta_keywords = meta_keywords;
     if (readTime) updateData.read_time = readTime;
 
-    // Set published_at if status is being changed to published
-    if (status === 'published') {
+    // Handle published_at date
+    if (published_at !== undefined) {
+      if (published_at && published_at.trim() !== '') {
+        updateData.published_at = published_at;
+      } else if (status === 'published') {
+        updateData.published_at = new Date().toISOString();
+      } else {
+        updateData.published_at = null;
+      }
+    } else if (status === 'published') {
       updateData.published_at = new Date().toISOString();
     }
 

--- a/app/api/blog/posts/route.ts
+++ b/app/api/blog/posts/route.ts
@@ -51,6 +51,7 @@ export async function POST(request: NextRequest) {
       author_avatar = 'Rishabh Jain.jpeg', // Handle both field names
       tags = [],
       status = 'draft',
+      published_at,
       meta_title,
       meta_description,
       meta_keywords = []
@@ -73,6 +74,16 @@ export async function POST(request: NextRequest) {
     const wordCount = JSON.stringify(content).split(' ').length;
     const readTime = Math.ceil(wordCount / 200);
 
+    // Determine published_at date
+    let finalPublishedAt = null;
+    if (status === 'published') {
+      if (published_at) {
+        finalPublishedAt = published_at;
+      } else {
+        finalPublishedAt = new Date().toISOString();
+      }
+    }
+
     const postData = {
       title,
       slug: finalSlug,
@@ -88,7 +99,7 @@ export async function POST(request: NextRequest) {
       meta_description,
       meta_keywords,
       read_time: readTime,
-      published_at: status === 'published' ? new Date().toISOString() : null
+      published_at: finalPublishedAt
     };
 
     const { data, error } = await supabase

--- a/components/blog/EnhancedBlogEditor.tsx
+++ b/components/blog/EnhancedBlogEditor.tsx
@@ -866,6 +866,24 @@ export default function EnhancedBlogEditor({ initialData, onSave, isSaving, mode
                     </SelectContent>
                   </Select>
                 </div>
+
+                <div>
+                  <Label htmlFor="published_at">Published Date</Label>
+                  <Input
+                    id="published_at"
+                    type="datetime-local"
+                    value={formData.published_at ? new Date(formData.published_at).toISOString().slice(0, 16) : ''}
+                    onChange={(e) => {
+                      const value = e.target.value ? new Date(e.target.value).toISOString() : '';
+                      handleInputChange('published_at', value);
+                    }}
+                    className="mt-1"
+                    placeholder="Select publication date"
+                  />
+                  <p className="text-sm text-gray-500 mt-1">
+                    Leave empty to use current date when publishing
+                  </p>
+                </div>
               </CardContent>
             </Card>
 

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -29,6 +29,7 @@ export interface BlogPostFormData {
   tags?: string[]
   featured_image?: string
   status: 'draft' | 'published'
+  published_at?: string
   meta_title?: string
   meta_description?: string
 }


### PR DESCRIPTION
✅ New Features:
- Added published_at field to BlogPostFormData interface
- Added datetime-local input field in blog editor
- Users can now set custom publication dates
- Date picker shows current published_at value when editing

✅ API Updates:
- Updated POST /api/blog/posts to handle published_at field
- Updated PUT /api/blog/posts/id/[id] to handle published_at updates
- Smart logic: uses custom date if provided, current date if published without custom date
- Proper handling of empty/null published_at values

✅ Editor Improvements:
- Published date field appears after status selection
- Helpful placeholder text explaining the feature
- Proper date formatting for datetime-local input
- Seamless integration with existing editor workflow

🎯 User Experience:
- Content creators can now schedule posts for specific dates
- Edit existing posts to change publication dates
- Backward compatible with existing posts
- Clear UI indicating when current date will be used